### PR TITLE
Fix condition for checking current user's receipts in ordersPage.js

### DIFF
--- a/scripts/pages/ordersPage.js
+++ b/scripts/pages/ordersPage.js
@@ -74,7 +74,7 @@ function runOrdersPage() {
         saveDataToLocalStorage('receipt', basket); // Spara aktivt kvitto
 
         // Lägg till beställningen i användarens kvittohistorik
-        if (currentUser || currentUser.receipts) {
+        if (currentUser && currentUser.receipts) {
             if (!currentUser.receipts) {
                 currentUser.receipts = [];
             }


### PR DESCRIPTION
FIxade till buggen som gav fel när man försökte lägga en order när currentUser var = null