### PR TITLE
Initialize receipts array for new users and ensure receipt history is…

### DIFF
--- a/scripts/components/register.js
+++ b/scripts/components/register.js
@@ -66,6 +66,7 @@ export async function registerUser(event, apiUsers) {
 		password,
 		profile_image: profileImage,
 		role: 'user',
+		receipts: [],
 	};
 
 	// Lägg till den nya användaren i localStorage

--- a/scripts/pages/ordersPage.js
+++ b/scripts/pages/ordersPage.js
@@ -75,7 +75,7 @@ function runOrdersPage() {
 		saveDataToLocalStorage('receipt', basket); // Spara aktivt kvitto
 
 		// Lägg till beställningen i användarens kvittohistorik
-		if (currentUser && currentUser.receipts) {
+		if (currentUser) {
 			if (!currentUser.receipts) {
 				currentUser.receipts = [];
 			}


### PR DESCRIPTION
Ändrat så att alla nya users får e nyckel i deras localstorage som är receipts: [ ] och fixat så att felhanteringen för om man inte har den nyckeln (de användarna från APIet) får det om de inte har det. 